### PR TITLE
fix: 修复导出

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,14 @@
       "import": "./dist/gdp.js",
       "require": "./dist/gdp.js"
     },
+    "./dist/gdp": {
+      "import": "./dist/gdp.js",
+      "require": "./dist/gdp.js"
+    },
+    "./dist/gdp-full": {
+      "import": "./dist/gdp-full.js",
+      "require": "./dist/gdp-full.js"
+    },
     "./gdp": {
       "import": "./dist/gdp.js",
       "require": "./dist/gdp.js"


### PR DESCRIPTION
解决
4） 如果您在引入过程中遇到找不到 gio-webjs-sdk/gdp-full 类似的情况，可以尝试使用 gio-webjs-sdk/dist/gdp-full 的路径解决。